### PR TITLE
Modify random number generation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -212,7 +212,7 @@ app.post( "/logout", ( req, res ) => {
     res.redirect("/");
 });
 
-import { generateQuestions } from "./modules/generator.mjs";
+import { Xorshift, generateQuestions } from "./modules/generator.mjs";
 
 var grade;
 var mod;

--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,9 @@ app.post("/", (req, res) => {
         }
         console.log(quiz.operations);
         quiz.grade = grade;
-        const generator = new Xorshift(Date.now() | 0);
+        const seed = Date.now() | 1;
+        console.log(seed);
+        const generator = new Xorshift(seed);
         result = generateQuestions(quiz, generator);
         counter = 0;
         totalcorrect = 0;

--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,8 @@ app.post("/", (req, res) => {
         }
         console.log(quiz.operations);
         quiz.grade = grade;
-        result = generateQuestions(quiz);
+        const generator = new Xorshift(Date.now() | 0);
+        result = generateQuestions(quiz, generator);
         counter = 0;
         totalcorrect = 0;
         timer_start();

--- a/src/index.js
+++ b/src/index.js
@@ -110,7 +110,7 @@ app.post("/", (req, res) => {
         console.log(quiz.operations);
         quiz.grade = grade;
         const seed = Date.now() | 1;
-        console.log(seed);
+        console.log("Seed: " + seed);
         const generator = new Xorshift(seed);
         result = generateQuestions(quiz, generator);
         counter = 0;

--- a/src/modules/generator.mjs
+++ b/src/modules/generator.mjs
@@ -61,7 +61,8 @@ function randomInteger(min, max, generator) {
     do {
         x = generator.generate() & mask;
     } while (x > range);
-    return x;
+    const y = x + min;
+    return y;
 }
 
 function generateAddition(grade, generator) {
@@ -75,9 +76,13 @@ function generateAddition(grade, generator) {
         }
     };
 
-    const answer = randomInteger(0, maxRange(), generator);
-    const firstOperand = answer - randomInteger(0, answer + 1, generator);
-    const secondOperand = answer - firstOperand;
+    const max = maxRange();
+    const answer = randomInteger(0, max, generator);
+    let secondOperand = 0;
+    do {
+        secondOperand = randomInteger(0, max, generator);
+    } while (secondOperand >= answer);
+    const firstOperand = answer - secondOperand;
 
     return {
         text: `${firstOperand} + ${secondOperand} = `,
@@ -85,7 +90,7 @@ function generateAddition(grade, generator) {
     };
 }
 
-function generateSubtraction(grade) {
+function generateSubtraction(grade, generator) {
     const maxRange = () => {
         if (grade <= 2) {
             return 11;
@@ -96,8 +101,12 @@ function generateSubtraction(grade) {
         }
     };
 
-    const firstOperand = randomInteger(0, maxRange());
-    const secondOperand = randomInteger(0, firstOperand + 1);
+    const max = maxRange();
+    const firstOperand = randomInteger(0, max, generator);
+    let secondOperand = 0;
+    do {
+        secondOperand = randomInteger(0, max, generator);
+    } while (secondOperand > firstOperand);
     const answer = firstOperand - secondOperand;
 
     return {
@@ -106,7 +115,7 @@ function generateSubtraction(grade) {
     };
 }
 
-function generateMultiplication(grade) {
+function generateMultiplication(grade, generator) {
     const maxRange = () => {
         if (grade <= 4) {
             return 11;
@@ -118,8 +127,8 @@ function generateMultiplication(grade) {
     };
 
     const maxFactor = maxRange();
-    const firstOperand = randomInteger(0, maxFactor);
-    const secondOperand = randomInteger(0, maxFactor);
+    const firstOperand = randomInteger(0, maxFactor, generator);
+    const secondOperand = randomInteger(0, maxFactor, generator);
     const answer = firstOperand * secondOperand;
 
     return {
@@ -128,25 +137,19 @@ function generateMultiplication(grade) {
     };
 }
 
-function generateDivision(grade) {
+function generateDivision(grade, generator) {
     const maxRange = () => {
-        if (grade <= 4) {
+        if (grade <= 5) {
             return 11;
         } else {
-            return 101;
+            return 16;
         }
     };
 
-    const firstOperand = randomInteger(0, maxRange());
-    const getSecondOperand = () => {
-        let x = 0;
-        do {
-            x = randomInteger(1, 101);
-        } while (firstOperand % x !== 0);
-        return x;
-    }
-    const secondOperand = getSecondOperand();
-    const answer = firstOperand / secondOperand;
+    const max = maxRange();
+    const secondOperand = randomInteger(1, max, generator);
+    const answer = randomInteger(0, max, generator);
+    const firstOperand = secondOperand * answer;
 
     return {
         text: `${firstOperand} / ${secondOperand} = `,

--- a/src/modules/generator.mjs
+++ b/src/modules/generator.mjs
@@ -36,6 +36,7 @@ function generateQuestions(options, generator) {
     return {grade: grade, questions: questions};
 }
 
+// Implements the standard xorshift algorithm with 32 bits of state
 class Xorshift {
     #state = 1;
 
@@ -43,6 +44,7 @@ class Xorshift {
         this.#state = seedValue;
     }
 
+    // Algorithm based on example from Wikipedia, itself by G. Marsaglia
     generate() {
         let x = this.#state;
         x ^= x << 13;
@@ -53,6 +55,8 @@ class Xorshift {
     }
 }
 
+// Bitmask with rejection algorithm from Apple's libc
+// Found on https://www.pcg-random.org/posts/bounded-rands.html
 function randomInteger(min, max, generator) {
     const range = (max - min) - 1;
     let mask = ~0;

--- a/src/modules/generator.mjs
+++ b/src/modules/generator.mjs
@@ -85,7 +85,7 @@ function generateAddition(grade, generator) {
     let secondOperand = 0;
     do {
         secondOperand = randomInteger(0, max, generator);
-    } while (secondOperand >= answer);
+    } while (secondOperand > answer);
     const firstOperand = answer - secondOperand;
 
     return {

--- a/src/modules/generator.mjs
+++ b/src/modules/generator.mjs
@@ -36,8 +36,26 @@ function generateQuestions(options) {
     return {grade: grade, questions: questions};
 }
 
-function randomInteger(min, max) {
-    return Math.floor(Math.random() * (max - min) + min);
+class Xorshift {
+    #state = 1;
+
+    constructor (seedValue) {
+        this.#state = seedValue;
+    }
+
+    generate() {
+        let x = this.#state;
+        x ^= x << 13;
+        x ^= x >>> 17;
+        x ^= x << 5;
+        this.#state = x;
+        return x;
+    }
+}
+
+function randomInteger(min, max, generator) {
+    const range = max - min;
+    return (generator.generate() % range) + min;
 }
 
 function generateAddition(grade) {
@@ -130,4 +148,4 @@ function generateDivision(grade) {
     };
 }
 
-export { generateQuestions };
+export { Xorshift, generateQuestions };


### PR DESCRIPTION
This request changes the generator algorithm to the xorshift algorithm and tweaks how certain questions are generated. The main goal was to eliminate the number of zeroes being generated in low grade addition.

The first attempt to fix this was by changing the random number generator. This did not solve the issue, but it did incidentally remove potential issues with thread safety, so I left it in.

The second attempt was to change how each number was generated.  It didn't fix it entirely, but it did seem like a good improvement.