### PR TITLE
Revert pRNG changes with license context

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,10 @@ app.post("/", (req, res) => {
         }
         console.log(quiz.operations);
         quiz.grade = grade;
-        result = generateQuestions(quiz);
+        const seed = Date.now() | 1;
+        console.log("Seed: " + seed);
+        const generator = new Xorshift(seed);
+        result = generateQuestions(quiz, generator);
         counter = 0;
         totalcorrect = 0;
         timer_start();
@@ -212,7 +215,7 @@ app.post( "/logout", ( req, res ) => {
     res.redirect("/");
 });
 
-import { generateQuestions } from "./modules/generator.mjs";
+import { Xorshift, generateQuestions } from "./modules/generator.mjs";
 
 var grade;
 var mod;

--- a/src/modules/generator.mjs
+++ b/src/modules/generator.mjs
@@ -1,3 +1,28 @@
+//  MIT License
+//
+//  Copyright (c) 2018 Melissa E. O'Neill
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a
+//  copy of this software and associated documentation files (the "Software"),
+//  to deal in the Software without restriction, including without limitation
+//  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the
+//  Software is furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+//  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+//  DEALINGS IN THE SOFTWARE.
+//
+// The function randomInteger contains licensed material
+// More details can be found above the function in question
+
 const questionGenerators = {
     addition: generateAddition,
     subtraction: generateSubtraction,
@@ -55,8 +80,12 @@ class Xorshift {
     }
 }
 
-// Bitmask with rejection algorithm from Apple's libc
-// Found on https://www.pcg-random.org/posts/bounded-rands.html
+// A modified version of the bitmask with rejection algorithm adapted to Javascript
+// This version of the algorithm was by Melissa E. O'Neill
+// https://github.com/imneme/bounded-rands/blob/master/bounded32.cpp
+// The algorithm was originally implemented in Apple's libc as the function
+// arc4random_uniform in /gen/FreeBSD/arc4random.c
+// https://opensource.apple.com/source/Libc/Libc-1439.141.1/gen/FreeBSD/arc4random.c.auto.html
 function randomInteger(min, max, generator) {
     const range = (max - min) - 1;
     let mask = ~0;


### PR DESCRIPTION
The previous changes to the pRNG are reverted back, but with a better context as to the use of licensed material. A followup PR will include a statement regarding this in the project README.