### PR TITLE
Add license reflection section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ the issue tracker.
 
 This project made use of external licensed code. The external code in question is
 in /src/modules/generator.mjs. The file contains an algorithm which originally
-appeared in Apple's libc, which was later iterated upon by Melissa E. O'Neill.
+appeared in Apple's libc, which was later iterated upon by Melissa E. O'Neill.[^1][^2]
 As of the time of writing, the file includes a copy of the MIT license with
 copywrite attributed to O'Neill. This was done because the code this project
 uses is heavily based on their work. The reasoning behind not needing to follow
@@ -51,3 +51,6 @@ the terms of the Apple Public Source License is that the iterated work is based
 on the concept of how the algorithm in question works rather than modifying the
 code. It is possible that reasoning is faulty. Even after consultation, the
 chosen course of action was done through judgement.
+
+[^1]: [Apple libc relevant source](https://opensource.apple.com/source/Libc/Libc-1439.141.1/gen/FreeBSD/arc4random.c.auto.html)
+[^2]: [O'Neill's relevant source](https://github.com/imneme/bounded-rands/blob/master/bounded32.cpp)

--- a/README.md
+++ b/README.md
@@ -31,3 +31,23 @@ This work is licensed under a
 [cc-by-sa]: http://creativecommons.org/licenses/by-sa/4.0/
 [cc-by-sa-image]: https://licensebuttons.net/l/by-sa/4.0/88x31.png
 [cc-by-sa-shield]: https://img.shields.io/badge/License-CC%20BY--SA%204.0-lightgrey.svg
+
+## License Reflection
+I, Taishi Barth (haitaim), take responsibility for the actions detailed in this
+section.
+
+For the purpose making this information as accessible and transparent as possible
+for this class project, the current section of the README will discuss the use of
+external code and how its use was handled. This section will also be repeated in
+the issue tracker. 
+
+This project made use of external licensed code. The external code in question is
+in /src/modules/generator.mjs. The file contains an algorithm which originally
+appeared in Apple's libc, which was later iterated upon by Melissa E. O'Neill.
+As of the time of writing, the file includes a copy of the MIT license with
+copywrite attributed to O'Neill. This was done because the code this project
+uses is heavily based on their work. The reasoning behind not needing to follow
+the terms of the Apple Public Source License is that the iterated work is based
+on the concept of how the algorithm in question works rather than modifying the
+code. It is possible that reasoning is faulty. Even after consultation, the
+chosen course of action was done through judgement.

--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ in /src/modules/generator.mjs. The file contains an algorithm which originally
 appeared in Apple's libc, which was later iterated upon by Melissa E. O'Neill.[^1][^2]
 As of the time of writing, the file includes a copy of the MIT license with
 copywrite attributed to O'Neill. This was done because the code this project
-uses is heavily based on their work. The reasoning behind not needing to follow
-the terms of the Apple Public Source License is that the iterated work is based
-on the concept of how the algorithm in question works rather than modifying the
-code. It is possible that reasoning is faulty. Even after consultation, the
-chosen course of action was done through judgement.
+uses is heavily based on their work. The changes done include having minimum and
+maximum values rather than a range, using the Javascript Math.clz32 rather than
+a compiler builtin, and adapting to Javascript variable declarations. The reasoning
+behind not needing to follow the terms of the Apple Public Source License is that
+the iterated work is based on the concept of how the algorithm in question works
+rather than modifying the code. It is possible that reasoning is faulty. Even after
+consultation, the chosen course of action was done through judgement.
 
 [^1]: [Apple libc relevant source](https://opensource.apple.com/source/Libc/Libc-1439.141.1/gen/FreeBSD/arc4random.c.auto.html)
 [^2]: [O'Neill's relevant source](https://github.com/imneme/bounded-rands/blob/master/bounded32.cpp)


### PR DESCRIPTION
This PR implements a license reflection section in the README.

This is a followup to #5.